### PR TITLE
Fix roulette result alignment

### DIFF
--- a/example/Roue.java
+++ b/example/Roue.java
@@ -238,10 +238,13 @@ public class Roue {
 
         double angleStep  = 360.0 / total;
         double extraTurns = 3.0 * OptionRoue.getSpinSpeed();  // nombre de tours entiers
+        // Calcule l'angle final à atteindre. On souhaite que le centre du
+        // secteur gagnant se retrouve exactement sous le curseur situé en haut
+        // de la roue (à 270°). Chaque tour complet est ajouté pour l'animation
+        // puis on soustrait la position du centre du secteur courant.
         double target     = (360 * extraTurns)
-                + (winningIndex * angleStep)
-                + (angleStep / 2.0)
-                - 90;  // on veut atterrir face au curseur
+                + 270
+                - ((winningIndex + 0.5) * angleStep);
 
         double start = groupSecteurs.getRotate();
         rotateTransition.setNode(groupSecteurs);


### PR DESCRIPTION
## Summary
- correct final rotation calculation so the winning sector lines up with the top cursor

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*